### PR TITLE
Simplify jump preview in element composer

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,17 +49,7 @@
         if (active === 'pane-jmp') {
           const rot = document.querySelector('input[name="rot"]:checked')?.value || '0';
           const type = document.querySelector('input[name="type"]:checked')?.value || '';
-          const flags = Array.from(document.querySelectorAll('input[name="flag"]:checked')).map(i=>i.value);
-          const rep = flags.includes('REP') ? '+REP' : '';
-          const suf = [flags.includes('!')?'!':'', flags.includes('e')?'e':'', flags.includes('UR')?'\u003c':'', flags.includes('DG')?'\u003c\u003c':'', flags.includes('*')?'*':''].join('');
-          const bonus = document.getElementById('bonus').checked ? ' x' : '';
-          const txt = (rot!=='0'?rot:'') + type + suf + (rep?rep:'') + bonus;
-          preview.textContent = txt || '要素';
-          // if (rot!=='0') chips.insertAdjacentHTML('beforeend', `<span class="chip"><i class="bi bi-arrow-repeat"></i>${rot}回転</span>`);
-          // if (type) chips.insertAdjacentHTML('beforeend', `<span class="chip"><i class="bi bi-circle"></i>${type}</span>`);
-          flags.forEach(f=> chips.insertAdjacentHTML('beforeend', `<span class="chip">${f}</span>`));
-          if (document.getElementById('spinV').checked) chips.insertAdjacentHTML('beforeend', `<span class="chip">V</span>`);
-          if (document.getElementById('bonus').checked) chips.insertAdjacentHTML('beforeend', `<span class="chip">x</span>`);
+          preview.textContent = ((rot !== '0' ? rot : '') + type) || '要素';
           return;
         }
 


### PR DESCRIPTION
## Summary
- Stop rendering jump flags and bonus chips in the element composer preview
- Show only rotation count and jump type in the preview text

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ... NODE`


------
https://chatgpt.com/codex/tasks/task_e_68bbbe5751b8832fbd9ae914b3268060