### PR TITLE
ジャンプ回転数選択の不具合を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,10 +513,19 @@
     function updateRotationButtons(){
       const type = document.querySelector('input[name="type"]:checked')?.value;
       const rotRadios = [0,1,2,3,4,5].map(n=>document.getElementById('rot'+n));
-      rotRadios.forEach(r=>{ if(r) r.disabled = true; });
-      if (!type){ if(rotRadios[0]) rotRadios[0].disabled=false; return; }
-      const avail = getAvailableRotationsFor(type);
-      rotRadios.forEach((r,idx)=>{ if(!r) return; if(idx===0 || avail.includes(idx)) r.disabled=false; });
+
+      // 一旦すべての回転数ボタンを有効化
+      rotRadios.forEach(r=>{ if(r) r.disabled = false; });
+
+      // ジャンプ種類が選択されている場合のみ制限を適用
+      if (type){
+        const avail = getAvailableRotationsFor(type);
+        rotRadios.forEach((r,idx)=>{
+          if(!r) return;
+          if(idx !== 0 && !avail.includes(idx)) r.disabled = true;
+        });
+      }
+
       // 5回転時はA無効
       const rot = document.querySelector('input[name="rot"]:checked')?.value;
       const aBtn = document.getElementById('tA');

--- a/script.js
+++ b/script.js
@@ -95,15 +95,20 @@ function initApp(){
 
 // 動的回転数制御関数
 function updateRotationButtons(jumpType) {
-  if (!jumpType) return;
-  
+  const rotationButtons = $("#nav-jmp .setLOD button");
+
+  // ジャンプ種類が未選択のときは全ての回転数を選択可能にする
+  if (!jumpType) {
+    rotationButtons.prop("disabled", false);
+    return;
+  }
+
   try {
     const availableRotations = getAvailableRotationsFor(jumpType);
-    const rotationButtons = $("#nav-jmp .setLOD button");
-    
+
     // すべて無効化
     rotationButtons.prop("disabled", true);
-    
+
     // 利用可能な回転数のボタンを有効化
     rotationButtons.each(function(index) {
       const rotation = parseInt($(this).text());
@@ -111,7 +116,7 @@ function updateRotationButtons(jumpType) {
         $(this).prop("disabled", false);
       }
     });
-    
+
     // 0回転は常に有効
     rotationButtons.eq(0).prop("disabled", false);
   } catch (error) {


### PR DESCRIPTION
## 概要
- ジャンプ種類未選択時でも回転数1〜5を選択可能にしました
- 回転数ボタンの初期化処理を改善しました

## テスト
- `npm test` (package.json が存在しないため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68bbe81b2158832fa5d62c0392853209