### PR TITLE
fix: prevent duplicate jump preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -811,11 +811,9 @@
         state.buffer.push(newPart());
         state.isComboMode = true;
 
-        // プレビュー表示を更新
-        renderPreview();
-        const preview = document.getElementById('elemPreview');
-        preview.textContent += '+';
+        // 選択状態をリセットしプレビューを更新
         resetSelections(false);
+        renderPreview();
       }
     }
 


### PR DESCRIPTION
## Summary
- reset selections before re-rendering preview in combo mode
- remove manual '+' from preview; handled by renderPreview

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfe940bf4832f970938a5ec27feac