### PR TITLE
Add quarter under-rotation flag for jumps

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,6 +178,7 @@
                   <div class="col-12">
                     <div class="text-secondary small mb-1">詳細</div>
                     <div class="d-flex flex-wrap gap-2">
+                      <input class="btn-check setQ" id="flagQ" type="checkbox" name="flag" value="q"><label class="btn btn-outline-secondary btn-sm" for="flagQ">q</label>
                       <input class="btn-check" id="flagUR" type="checkbox" name="flag" value="UR"><label class="btn btn-outline-secondary btn-sm" for="flagUR">&lt;</label>
                       <input class="btn-check" id="flagDG" type="checkbox" name="flag" value="DG"><label class="btn btn-outline-secondary btn-sm" for="flagDG">&lt;&lt;</label>
                       <input class="btn-check" id="flagATT" type="checkbox" name="flag" value="!"><label class="btn btn-outline-secondary btn-sm" for="flagATT">!</label>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@ var buffer = [{
   lod: "0",
   ur: false,
   dg: false,
+  q: false,
   edge: false,
   rep: false,
   spinV: false,
@@ -57,6 +58,7 @@ function initApp(){
   $(".setLOD button").click(setLOD);
   $(".setUr").click(setUr);
   $(".setDg").click(setDg);
+  $(".setQ").click(setQ);
   $(".setEdge").click(setEdge);
   $(".setREP").click(setREP);
   $(".setBonus").click(setBonus);
@@ -354,6 +356,7 @@ function setLOD(){
 
 function setUr(){
   buffer[buffer.length - 1].ur = !buffer[buffer.length - 1].ur;
+  buffer[buffer.length - 1].q = false;
   buffer[buffer.length - 1].dg = false;
   setType(this);
   renderBufferedElement();
@@ -363,6 +366,16 @@ function setDg(){
   buffer[buffer.length - 1].dg = !buffer[buffer.length - 1].dg;
   //elementDisplay.append("<<");
   buffer[buffer.length - 1].ur = false;
+  buffer[buffer.length - 1].q = false;
+  setType(this);
+  renderBufferedElement();
+}
+
+function setQ(){
+  const b = buffer[buffer.length - 1];
+  b.q = !b.q;
+  b.ur = false;
+  b.dg = false;
   setType(this);
   renderBufferedElement();
 }
@@ -422,6 +435,7 @@ function addJump(){
     lod: "0",
     ur: false,
     dg: false,
+    q: false,
     edge: false,
     rep: false,
     spinV: false,
@@ -452,6 +466,9 @@ function renderBufferedElement(){
       }
       if (buffer[i].name !== null){
         elementDisplay.append(buffer[i].name);
+      }
+      if (buffer[i].q !== false){
+        elementDisplay.append("q");
       }
       if (buffer[i].edge !== false){
         elementDisplay.append("e");
@@ -525,6 +542,7 @@ function clearEntry() {
     lod: "0",
     ur: false,
     dg: false,
+    q: false,
     edge: false,
     rep: false,
     spinV: false,
@@ -825,6 +843,7 @@ function getElementDisplayText(parts){
     if (p.type === "jump"){
       if (p.lod != null && p.lod != 0){ out += String(p.lod); }
       if (p.name !== null){ out += p.name; }
+      if (p.q){ out += "q"; }
       if (p.edge){ out += "e"; }
       if (p.ur){ out += "<"; }
       if (p.dg){ out += "<<"; }


### PR DESCRIPTION
## Summary
- Add `q` checkbox to jump detail controls for 1/4 under-rotation
- Wire new flag through buffer and rendering, including toggle handler
- Display `q` in element text without altering scoring logic

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc01faabbc832f8ddb8efaa881f48e